### PR TITLE
RFC: Spike for a better way of encapsulating config for providers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,23 +1,17 @@
 package config
 
+import (
+	"encoding/json"
+)
+
 const (
 	// MappingFile mapping file environment variable
 	MappingFile = "MAPPING_FILE"
 )
 
-// RabbitEntry RabbitMQ mapping entry
-type RabbitEntry struct {
-	Type          string `json:"type"`
-	Name          string `json:"name"`
-	ConnectionURL string `json:"connection"`
-	ExchangeName  string `json:"topic"`
-	QueueName     string `json:"queue"`
-	RoutingKey    string `json:"routing"`
-}
-
-// AmazonEntry SQS/SNS mapping entry
-type AmazonEntry struct {
-	Type   string `json:"type"`
-	Name   string `json:"name"`
-	Target string `json:"target"`
+// Entry Generic config entry
+type Entry struct {
+	Type   string                 `json:"type"`
+	Name   string                 `json:"name"`
+	Config *json.RawMessage       `json:"config"`
 }

--- a/examples/rabbit_to_lambda.v2.json
+++ b/examples/rabbit_to_lambda.v2.json
@@ -1,0 +1,21 @@
+[
+  {
+    "source" : {
+      "type" : "RabbitMQ",
+      "name" : "test-rabbit",
+      "config" : {
+        "connection" : "amqp://guest:guest@localhost:5672/",
+        "topic" : "amq.topic",
+        "queue" : "test-queue",
+        "routing" : "#"
+      }
+    },
+    "destination" : {
+      "type" : "Lambda",
+      "name" : "test-lambda",
+      "config" : {
+        "function" : "test-forwarder-lambda"
+      }
+    }
+  }
+]

--- a/examples/rabbit_to_lambda.v2.json
+++ b/examples/rabbit_to_lambda.v2.json
@@ -14,6 +14,7 @@
       "type" : "Lambda",
       "name" : "test-lambda",
       "config" : {
+        "configversion" : "v2",
         "function" : "test-forwarder-lambda"
       }
     }

--- a/examples/rabbit_to_sns.v2.json
+++ b/examples/rabbit_to_sns.v2.json
@@ -1,0 +1,23 @@
+[
+  {
+    
+    "source" : {
+      "type" : "RabbitMQ",
+      "name" : "test-rabbit",
+      "config" : {
+        "connection" : "amqp://guest:guest@localhost:5672/",
+        "topic" : "amq.topic",
+        "queue" : "test-queue",
+        "routing" : "#"
+      }
+    },
+    "destination" : {
+      "configversion" : "2",
+      "type" : "SNS",
+      "name" : "test-sns",
+      "config" : {
+        "topic" : "arn:aws:sns:eu-west-1:XXXXXXXX:test-forwarder"
+      }
+    }
+  }
+]

--- a/examples/rabbit_to_sns.v2.json
+++ b/examples/rabbit_to_sns.v2.json
@@ -16,6 +16,7 @@
       "type" : "SNS",
       "name" : "test-sns",
       "config" : {
+        "configversion" : "v2",
         "topic" : "arn:aws:sns:eu-west-1:XXXXXXXX:test-forwarder"
       }
     }

--- a/examples/rabbit_to_sqs.v2.json
+++ b/examples/rabbit_to_sqs.v2.json
@@ -1,0 +1,23 @@
+[
+  {
+    "source" : {
+      "configversion" : "2",
+      "type" : "RabbitMQ",
+      "name" : "test-rabbit",
+      "config" : {
+        "connection" : "amqp://guest:guest@localhost:5672/",
+        "topic" : "amq.topic",
+        "queue" : "test-queue",
+        "routing" : "#"
+      }
+    },
+    "destination" : {
+      "configversion" : "2",
+      "type" : "SQS",
+      "name" : "test-queue",
+      "config" : {
+        "queue" : "https://sqs.eu-west-1.amazonaws.com/XXXXXXXXX/test-queue"
+      }
+    }
+  }
+]

--- a/examples/rabbit_to_sqs.v2.json
+++ b/examples/rabbit_to_sqs.v2.json
@@ -16,6 +16,7 @@
       "type" : "SQS",
       "name" : "test-queue",
       "config" : {
+        "configversion" : "v2",
         "queue" : "https://sqs.eu-west-1.amazonaws.com/XXXXXXXXX/test-queue"
       }
     }

--- a/lambda/forwarder_test.go
+++ b/lambda/forwarder_test.go
@@ -1,6 +1,7 @@
 package lambda
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -18,9 +19,14 @@ const (
 )
 
 func TestCreateForwarder(t *testing.T) {
-	entry := config.AmazonEntry{Type: "Lambda",
+	rawConfig, _ := json.Marshal(Config{
+		Function: "lambda-test",
+	})
+
+	entry := config.Entry{
+		Type:   "Lambda",
 		Name:   "lambda-test",
-		Target: "function1-test",
+		Config: (*json.RawMessage)(&rawConfig),
 	}
 	forwarder := CreateForwarder(entry)
 	if forwarder.Name() != entry.Name {
@@ -30,9 +36,14 @@ func TestCreateForwarder(t *testing.T) {
 
 func TestPush(t *testing.T) {
 	functionName := "function1-test"
-	entry := config.AmazonEntry{Type: "Lambda",
+
+	rawConfig, _ := json.Marshal(Config{
+		Function: functionName,
+	})
+
+	entry := config.Entry{Type: "Lambda",
 		Name:   "lambda-test",
-		Target: functionName,
+		Config: (*json.RawMessage)(&rawConfig),
 	}
 	scenarios := []struct {
 		name     string

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -20,8 +20,21 @@ const (
 	snsType    = "sns"
 )
 
-func TestLoad(t *testing.T) {
+func TestLoadV0(t *testing.T) {
 	os.Setenv(config.MappingFile, "../tests/rabbit_to_sns.json")
+	client := New(MockMappingHelper{})
+	var consumerForwarderMap map[consumer.Client]forwarder.Client
+	var err error
+	if consumerForwarderMap, err = client.Load(); err != nil {
+		t.Errorf("could not load mapping and start mocked rabbit->sns pair: %s", err.Error())
+	}
+	if len(consumerForwarderMap) != 1 {
+		t.Errorf("wrong consumerForwarderMap size, expected 1, got %d", len(consumerForwarderMap))
+	}
+}
+
+func TestLoadV2(t *testing.T) {
+	os.Setenv(config.MappingFile, "../tests/rabbit_to_sns.v2.json")
 	client := New(MockMappingHelper{})
 	var consumerForwarderMap map[consumer.Client]forwarder.Client
 	var err error
@@ -109,7 +122,7 @@ func TestCreateForwarderLambda(t *testing.T) {
 	client := New(MockMappingHelper{})
 	forwarderName := "test-lambda"
 
-	rawConfig, _ := json.Marshal(lambda.Config{
+	rawConfig, _ := json.Marshal(lambda.ConfigV2{
 		Function: "function-name",
 	})
 

--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -25,10 +25,11 @@ const (
 
 // Config RabbitMQ config entry
 type Config struct {
-	ConnectionURL string `json:"connection"`
-	ExchangeName  string `json:"topic"`
-	QueueName     string `json:"queue"`
-	RoutingKey    string `json:"routing"`
+	Configversion *string `json:"configversion"`
+	ConnectionURL string  `json:"connection"`
+	ExchangeName  string  `json:"topic"`
+	QueueName     string  `json:"queue"`
+	RoutingKey    string  `json:"routing"`
 }
 
 // Consumer implementation or RabbitMQ consumer
@@ -57,6 +58,10 @@ func CreateConsumer(entry config.Entry) consumer.Client {
 	var config Config
 	if err := json.Unmarshal(*entry.Config, &config); err != nil {
 		return nil
+	}
+
+	if config.Configversion == nil {
+		log.Warn("Looks like you're using an old config format version or have forgotten the configversion parameter. We will try and recover")
 	}
 
 	return Consumer{entry.Name, config}

--- a/sns/forwarder.go
+++ b/sns/forwarder.go
@@ -21,7 +21,8 @@ const (
 
 // Config a struct representing the json config
 type Config struct {
-	Topic string `json:"topic"`
+	Configversion *string `json:"configversion"`
+	Topic         string  `json:"topic"`
 }
 
 // Forwarder forwarding client
@@ -42,6 +43,10 @@ func CreateForwarder(entry config.Entry, snsClient ...snsiface.SNSAPI) forwarder
 	var config Config
 	if err := json.Unmarshal(*entry.Config, &config); err != nil {
 		return nil
+	}
+
+	if config.Configversion == nil {
+		log.Warn("Looks like you're using an old config format version or have forgotten the configversion parameter. We will try and recover")
 	}
 
 	var client snsiface.SNSAPI

--- a/sns/forwarder_test.go
+++ b/sns/forwarder_test.go
@@ -1,6 +1,7 @@
 package sns
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -14,9 +15,14 @@ import (
 var badRequest = "Bad request"
 
 func TestCreateForwarder(t *testing.T) {
-	entry := config.AmazonEntry{Type: "SNS",
+	rawConfig, _ := json.Marshal(Config{
+		Topic: "topic1",
+	})
+
+	entry := config.Entry{
+		Type:   "SNS",
 		Name:   "sns-test",
-		Target: "arn",
+		Config: (*json.RawMessage)(&rawConfig),
 	}
 	forwarder := CreateForwarder(entry)
 	if forwarder.Name() != entry.Name {
@@ -26,10 +32,17 @@ func TestCreateForwarder(t *testing.T) {
 
 func TestPush(t *testing.T) {
 	topicName := "topic1"
-	entry := config.AmazonEntry{Type: "SNS",
+
+	rawConfig, _ := json.Marshal(Config{
+		Topic: topicName,
+	})
+
+	entry := config.Entry{
+		Type:   "SNS",
 		Name:   "sns-test",
-		Target: topicName,
+		Config: (*json.RawMessage)(&rawConfig),
 	}
+
 	scenarios := []struct {
 		name    string
 		mock    snsiface.SNSAPI

--- a/sns/forwarder_test.go
+++ b/sns/forwarder_test.go
@@ -16,7 +16,8 @@ var badRequest = "Bad request"
 
 func TestCreateForwarder(t *testing.T) {
 	rawConfig, _ := json.Marshal(Config{
-		Topic: "topic1",
+		Topic:         "topic1",
+		Configversion: aws.String("v2"),
 	})
 
 	entry := config.Entry{
@@ -34,7 +35,8 @@ func TestPush(t *testing.T) {
 	topicName := "topic1"
 
 	rawConfig, _ := json.Marshal(Config{
-		Topic: topicName,
+		Configversion: aws.String("v2"),
+		Topic:         topicName,
 	})
 
 	entry := config.Entry{

--- a/sqs/forwarder.go
+++ b/sqs/forwarder.go
@@ -21,7 +21,8 @@ const (
 
 // Config i
 type Config struct {
-	Queue string `json:"queue"`
+	Queue         string  `json:"queue"`
+	Configversion *string `json:"configversion"`
 }
 
 // Forwarder forwarding client
@@ -42,6 +43,10 @@ func CreateForwarder(entry config.Entry, sqsClient ...sqsiface.SQSAPI) forwarder
 	var config Config
 	if err := json.Unmarshal(*entry.Config, &config); err != nil {
 		return nil
+	}
+
+	if config.Configversion == nil {
+		log.Warn("Looks like you're using an old config format version or have forgotten the configversion parameter. We will try and recover")
 	}
 
 	var client sqsiface.SQSAPI

--- a/sqs/forwarder_test.go
+++ b/sqs/forwarder_test.go
@@ -1,6 +1,7 @@
 package sqs
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -14,10 +15,16 @@ import (
 var badRequest = "Bad request"
 
 func TestCreateForwarder(t *testing.T) {
-	entry := config.AmazonEntry{Type: "SQS",
+	rawConfig, _ := json.Marshal(Config{
+		Queue: "arn",
+	})
+
+	entry := config.Entry{
+		Type:   "SQS",
 		Name:   "sqs-test",
-		Target: "arn",
+		Config: (*json.RawMessage)(&rawConfig),
 	}
+
 	forwarder := CreateForwarder(entry)
 	if forwarder.Name() != entry.Name {
 		t.Errorf("wrong forwarder name, expected:%s, found: %s", entry.Name, forwarder.Name())
@@ -26,10 +33,17 @@ func TestCreateForwarder(t *testing.T) {
 
 func TestPush(t *testing.T) {
 	queueName := "queue1"
-	entry := config.AmazonEntry{Type: "SQS",
+
+	rawConfig, _ := json.Marshal(Config{
+		Queue: queueName,
+	})
+
+	entry := config.Entry{
+		Type:   "SQS",
 		Name:   "sqs-test",
-		Target: queueName,
+		Config: (*json.RawMessage)(&rawConfig),
 	}
+
 	scenarios := []struct {
 		name    string
 		mock    sqsiface.SQSAPI

--- a/sqs/forwarder_test.go
+++ b/sqs/forwarder_test.go
@@ -16,7 +16,8 @@ var badRequest = "Bad request"
 
 func TestCreateForwarder(t *testing.T) {
 	rawConfig, _ := json.Marshal(Config{
-		Queue: "arn",
+		Queue:         "arn",
+		Configversion: aws.String("v2"),
 	})
 
 	entry := config.Entry{
@@ -35,7 +36,8 @@ func TestPush(t *testing.T) {
 	queueName := "queue1"
 
 	rawConfig, _ := json.Marshal(Config{
-		Queue: queueName,
+		Queue:         queueName,
+		Configversion: aws.String("v2"),
 	})
 
 	entry := config.Entry{

--- a/tests/rabbit_to_sns.v2.json
+++ b/tests/rabbit_to_sns.v2.json
@@ -16,6 +16,7 @@
       "type" : "SNS",
       "name" : "test-sns",
       "config" : {
+        "configversion" : "v2",
         "target" : "arn:aws:sns:eu-west-1:XXXXXXXX:test-forwarder"
       }
     }

--- a/tests/rabbit_to_sns.v2.json
+++ b/tests/rabbit_to_sns.v2.json
@@ -1,0 +1,23 @@
+[
+  {
+    "source" : {
+      "configversion" : 2,
+      "type" : "RabbitMQ",
+      "name" : "test-rabbit",
+      "config" : {
+        "connection" : "amqp://guest:guest@localhost:5672/",
+        "topic" : "amq.topic",
+        "queue" : "test-queue",
+        "routing" : "#"
+      }
+    },
+    "destination" : {
+      "configversion" : "2.0",
+      "type" : "SNS",
+      "name" : "test-sns",
+      "config" : {
+        "target" : "arn:aws:sns:eu-west-1:XXXXXXXX:test-forwarder"
+      }
+    }
+  }
+]

--- a/tests/rabbit_to_sqs.v2.json
+++ b/tests/rabbit_to_sqs.v2.json
@@ -1,0 +1,23 @@
+[
+  {
+    "source" : {
+      "configversion" : 2,
+      "type" : "RabbitMQ",
+      "name" : "test-rabbit",
+      "config" : {
+        "connection" : "amqp://guest:guest@localhost:5672/",
+        "topic" : "amq.topic",
+        "queue" : "test-queue",
+        "routing" : "#"
+      }
+    },
+    "destination" : {
+      "configversion" : 2,
+      "type" : "SQS",
+      "name" : "test-queue",
+      "config" : {
+        "target" : "https://sqs.eu-west-1.amazonaws.com/XXXXXXXXX/test-queue"
+      }
+    }
+  }
+]

--- a/tests/rabbit_to_sqs.v2.json
+++ b/tests/rabbit_to_sqs.v2.json
@@ -16,6 +16,7 @@
       "type" : "SQS",
       "name" : "test-queue",
       "config" : {
+        "configversion" : "v2",
         "target" : "https://sqs.eu-west-1.amazonaws.com/XXXXXXXXX/test-queue"
       }
     }


### PR DESCRIPTION
A spike for encapsulating configs a little more generically. Let me know what you think of the direction.

I'm struggling to get a clean implementation to maintain backwards compatibility. From a structure point of view I like this http://devel.io/2013/08/19/go-handling-arbitrary-json/, but requires bringing in bson, which I don't really want to do. I'll tinker a bit more today and see if I can find something that works. If you have any suggestions. Ideally I'd want to push the old structure to the providers to deal with, but can't figure a good way to do that.